### PR TITLE
Add Helm chart for inventory service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.DS_Store
 **/*.tgz
+**/secrets.*.yaml

--- a/charts/kube-cards-ingress/requirements.lock
+++ b/charts/kube-cards-ingress/requirements.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: kube-cards-website
   repository: file://../../src/kube-cards-website/charts/kube-cards-website
   version: 0.1.0
-digest: sha256:0a057c6560c73a1e356259d4cf42232ff63633555a996338c4b85455346e727c
-generated: 2019-05-10T11:03:57.551762-07:00
+- name: kube-cards-inventory-service
+  repository: file://../../src/CardInventoryService/charts/kube-cards-inventory-service
+  version: 0.1.0
+digest: sha256:84aea9a57c2cb878c51a63e031d33cd8ebe31c7d88d1e51e23f29854d4df8751
+generated: 2019-05-23T16:33:29.52265-07:00

--- a/charts/kube-cards-ingress/requirements.yaml
+++ b/charts/kube-cards-ingress/requirements.yaml
@@ -2,3 +2,6 @@ dependencies:
   - name: kube-cards-website
     version: 0.1.0
     repository: file://../../src/kube-cards-website/charts/kube-cards-website
+  - name: kube-cards-inventory-service
+    version: 0.1.0
+    repository: file://../../src/CardInventoryService/charts/kube-cards-inventory-service

--- a/charts/kube-cards-ingress/templates/NOTES.txt
+++ b/charts/kube-cards-ingress/templates/NOTES.txt
@@ -1,8 +1,0 @@
-1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
-  {{- end }}
-{{- end }}
-{{- end }}

--- a/charts/kube-cards-ingress/templates/ingress.yaml
+++ b/charts/kube-cards-ingress/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- $fullName := include "kube-cards-ingress.fullname" . -}}
 {{- $websiteFullName := include "kube-cards-ingress.websitefullname" . -}}
+{{- $inventoryServiceFullName := include "kube-cards-ingress.inventoryservicefullname" . -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -28,14 +29,14 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
-        {{- range .paths }}
-          - path: {{ . }}
+          - path: /api/cards
+            backend:
+              serviceName: {{ $inventoryServiceFullName }}
+              servicePort: http
+          - path: /
             backend:
               serviceName: {{ $websiteFullName }}
               servicePort: http
-        {{- end }}
-  {{- end }}

--- a/charts/kube-cards-ingress/values.yaml
+++ b/charts/kube-cards-ingress/values.yaml
@@ -2,10 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-nginx-ingress:
-  controller:
-    replicaCount: 2
-
 nameOverride: ""
 fullnameOverride: ""
 

--- a/charts/values.prod.ingress.yaml
+++ b/charts/values.prod.ingress.yaml
@@ -1,6 +1,4 @@
 ingress:
-  issuer: letsencrypt-prod
-
   hosts:
   - host: prod.kubecards.net
     paths: [ / ]

--- a/charts/values.prod.yaml
+++ b/charts/values.prod.yaml
@@ -1,7 +1,5 @@
 kube-cards-ingress:
   ingress:
-    issuer: letsencrypt-prod
-
     hosts:
     - host: prod.kubecards.net
       paths: [ / ]

--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+npm-debug.log
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+.env
+*/bin
+*/obj
+README.md
+LICENSE
+.vscode

--- a/src/CardInventoryService/Dockerfile
+++ b/src/CardInventoryService/Dockerfile
@@ -1,0 +1,19 @@
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS base
+WORKDIR /app
+EXPOSE 80
+
+FROM microsoft/dotnet:2.2-sdk AS build
+WORKDIR /src
+COPY ["CardInventoryService/CardInventoryService.csproj", "CardInventoryService/"]
+RUN dotnet restore "CardInventoryService/CardInventoryService.csproj"
+COPY . .
+WORKDIR "/src/CardInventoryService"
+RUN dotnet build "CardInventoryService.csproj" -c Release -o /app
+
+FROM build AS publish
+RUN dotnet publish "CardInventoryService.csproj" -c Release -o /app
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app .
+ENTRYPOINT ["dotnet", "CardInventoryService.dll"]

--- a/src/CardInventoryService/azure-pipelines.yml
+++ b/src/CardInventoryService/azure-pipelines.yml
@@ -1,0 +1,30 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- task: Docker@2
+  displayName: Login to ACR
+  inputs:
+    command: login
+    containerRegistry: container-tools-kubecardsregistry
+- task: Docker@2
+  displayName: Build
+  inputs:
+    command: build
+    dockerFile: src/CardInventoryService/Dockerfile
+    buildContext: src
+    repository: kube-cards-inventory-service
+- task: Docker@2
+  displayName: Push
+  inputs:
+    command: push
+    containerRegistry: container-tools-kubecardsregistry
+    repository: kube-cards-inventory-service

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/.helmignore
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/Chart.yaml
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: kube-cards-inventory-service
+version: 0.1.0

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/templates/NOTES.txt
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kube-cards-inventory-service.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "kube-cards-inventory-service.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kube-cards-inventory-service.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kube-cards-inventory-service.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/templates/_helpers.tpl
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "kube-cards-ingress.name" -}}
+{{- define "kube-cards-inventory-service.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -11,7 +11,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "kube-cards-ingress.fullname" -}}
+{{- define "kube-cards-inventory-service.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -25,26 +25,8 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "kube-cards-ingress.websitefullname" -}}
-{{- printf "%s-%s" .Release.Name "kube-cards-website" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "kube-cards-ingress.inventoryservicefullname" -}}
-{{- printf "%s-%s" .Release.Name "kube-cards-inventory-service" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "kube-cards-ingress.chart" -}}
+{{- define "kube-cards-inventory-service.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/templates/deployment.yaml
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/templates/deployment.yaml
@@ -23,18 +23,53 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kube-cards-inventory-service.fullname" . }}
+                  key: environment
+            - name: AAD_B2C_Instance
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kube-cards-inventory-service.fullname" . }}
+                  key: b2cInstance
+            - name: AAD_B2C_ClientId
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kube-cards-inventory-service.fullname" . }}
+                  key: b2cClientId
+            - name: AAD_B2C_Domain
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kube-cards-inventory-service.fullname" . }}
+                  key: b2cDomain
+            - name: AAD_B2C_SignUpSignInPolicyId
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kube-cards-inventory-service.fullname" . }}
+                  key: b2cSignUpSignInPolicyId
+            - name: CardsDBConnectionString
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kube-cards-inventory-service.fullname" . }}
+                  key: cardsDbConnectionString
           ports:
             - name: http
               containerPort: 80
               protocol: TCP
+          {{- if .Values.probes.liveness }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /live
               port: http
+          {{- end }}
+          {{- if .Values.probes.readyness }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /ready
               port: http
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/templates/deployment.yaml
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/templates/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kube-cards-inventory-service.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kube-cards-inventory-service.name" . }}
+    helm.sh/chart: {{ include "kube-cards-inventory-service.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kube-cards-inventory-service.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "kube-cards-inventory-service.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/templates/secret.yaml
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/templates/secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kube-cards-inventory-service.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kube-cards-inventory-service.name" . }}
+    helm.sh/chart: {{ include "kube-cards-inventory-service.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+stringData:
+  environment: {{ .Values.secrets.environment }}
+  b2cInstance: {{ .Values.secrets.b2cInstance }}
+  b2cClientId: {{ .Values.secrets.b2cClientId }}
+  b2cDomain: {{ .Values.secrets.b2cDomain }}
+  b2cSignUpSignInPolicyId: {{ .Values.secrets.b2cSignUpSignInPolicyId }}
+  cardsDbConnectionString: {{ .Values.secrets.cardsDbConnectionString }}

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/templates/service.yaml
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kube-cards-inventory-service.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kube-cards-inventory-service.name" . }}
+    helm.sh/chart: {{ include "kube-cards-inventory-service.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "kube-cards-inventory-service.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/templates/tests/test-connection.yaml
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "kube-cards-inventory-service.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "kube-cards-inventory-service.name" . }}
+    helm.sh/chart: {{ include "kube-cards-inventory-service.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "kube-cards-inventory-service.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/values.yaml
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: nginx
-  tag: stable
+  repository: kubecardsregistry.azurecr.io/kube-cards-inventory-service
+  tag: "2703897"
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/values.yaml
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/values.yaml
@@ -1,23 +1,20 @@
-# Default values for kube-cards-ingress.
+# Default values for kube-cards-inventory-service.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-nginx-ingress:
-  controller:
-    replicaCount: 2
+replicaCount: 1
+
+image:
+  repository: nginx
+  tag: stable
+  pullPolicy: IfNotPresent
 
 nameOverride: ""
 fullnameOverride: ""
 
-ingress:
-  issuer: letsencrypt-prod
-
-  host: staging.kubecards.net
-
-  tls:
-    - hosts:
-      - staging.kubecards.net
-      secretName: tls-staging-secret
+service:
+  type: ClusterIP
+  port: 80
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/src/CardInventoryService/charts/kube-cards-inventory-service/values.yaml
+++ b/src/CardInventoryService/charts/kube-cards-inventory-service/values.yaml
@@ -9,6 +9,18 @@ image:
   tag: "2703897"
   pullPolicy: IfNotPresent
 
+secrets:
+  environment: ""
+  b2cInstance: ""
+  b2cClientId: ""
+  b2cDomain: ""
+  b2cSignUpSignInPolicyId: ""
+  cardsDbConnectionString: ""
+
+probes:
+  liveness: true
+  readyness: true
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/src/kube-cards-website/charts/kube-cards-website/templates/deployment.yaml
+++ b/src/kube-cards-website/charts/kube-cards-website/templates/deployment.yaml
@@ -23,6 +23,27 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: MSAL_AUTHORITY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kube-cards-website.fullname" . }}
+                  key: msalAuthority
+            - name: MSAL_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kube-cards-website.fullname" . }}
+                  key: msalClientId
+            - name: MSAL_IMPERSONATION_SCOPE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kube-cards-website.fullname" . }}
+                  key: msalImpersonationScope
+            - name: CARDS_INVENTORY_SERVICE_BASE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kube-cards-website.fullname" . }}
+                  key: cardsInventoryServiceBaseUri
           ports:
             - name: http
               containerPort: 80

--- a/src/kube-cards-website/charts/kube-cards-website/templates/secret.yaml
+++ b/src/kube-cards-website/charts/kube-cards-website/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kube-cards-website.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kube-cards-website.name" . }}
+    helm.sh/chart: {{ include "kube-cards-website.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+stringData:
+  msalAuthority: {{ .Values.secrets.msalAuthority }}
+  msalClientId: {{ .Values.secrets.msalClientId }}
+  msalImpersonationScope: {{ .Values.secrets.msalImpersonationScope }}
+  cardsInventoryServiceBaseUri: {{ .Values.secrets.cardsInventoryServiceBaseUri }}

--- a/src/kube-cards-website/charts/kube-cards-website/values.yaml
+++ b/src/kube-cards-website/charts/kube-cards-website/values.yaml
@@ -6,8 +6,14 @@ replicaCount: 1
 
 image:
   repository: kubecardsregistry.azurecr.io/kube-cards-website
-  tag: "2652253"
+  tag: "2703277"
   pullPolicy: IfNotPresent
+
+secrets:
+  msalAuthority: ""
+  msalClientId: ""
+  msalImpersonationScope: ""
+  cardsInventoryServiceBaseUri: ""
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Sketch a Helm chart for the inventory service.  Update charts to pull environment variables needed for front- and back-ends from secrets added to cluster via deploy-time YAML override.